### PR TITLE
Resovles #2, From image hseeberger/scala-sbt:8u222_1.3.5_2.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt
+FROM hseeberger/scala-sbt:8u222_1.3.5_2.13.1
 
 RUN mkdir -p /root/.sbt/1.0/plugins
 RUN echo "\


### PR DESCRIPTION
hseeberger/scala-sbt:latest tag image is not available on hub.docker.com.

Looking forward to Mastering functional programming 👍 